### PR TITLE
Big re-work

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,28 +71,28 @@ func (client *Client) Timeout() uint16 {
 //
 // You would need to set attributes manually via *set_attributes()* function
 func (client *Client) CreateRadiusPacket(typeCode protocol.TypeCode) protocol.RadiusPacket {
-  return protocol.InitialiseRadPacket(typeCode)
+  return protocol.InitialiseRadiusPacket(typeCode)
 }
 
 // CreateAuthRadiusPacket creates RADIUS packet with AccessRequest TypeCode without attributes
 //
 // You would need to set attributes manually via *set_attributes()* function
 func (client *Client) CreateAuthRadiusPacket() protocol.RadiusPacket {
-  return protocol.InitialiseRadPacket(protocol.AccessRequest)
+  return protocol.InitialiseRadiusPacket(protocol.AccessRequest)
 }
 
 // CreateAcctRadiusPacket creates RADIUS packet with AccountingRequest TypeCode without attributes
 //
 // You would need to set attributes manually via *set_attributes()* function
 func (client *Client) CreateAcctRadiusPacket() protocol.RadiusPacket {
-  return protocol.InitialiseRadPacket(protocol.AccountingRequest)
+  return protocol.InitialiseRadiusPacket(protocol.AccountingRequest)
 }
 
 // CreateCoaRadiusPacket creates RADIUS packet with CoARequest TypeCode without attributes
 //
 // You would need to set attributes manually via *set_attributes()* function
 func (client *Client) CreateCoaRadiusPacket() protocol.RadiusPacket {
-  return protocol.InitialiseRadPacket(protocol.CoARequest)
+  return protocol.InitialiseRadiusPacket(protocol.CoARequest)
 }
 
 // CreateAttributeByName creates RADIUS packet attribute by Name, that is defined in dictionary file
@@ -140,8 +140,8 @@ func (client *Client) RadiusAttrOriginalIntegerValue(attribute protocol.RadiusAt
 }
 
 // InitialisePacketFromBytes creates RADIUS packet attribute by ID, that is defined in dictionary file
-func (client *Client) InitialisePacketFromBytes(reply *[]uint8) (protocol.RadiusPacket, error) {
-  return client.host.InitialisePacketFromBytes(reply)
+func (client *Client) InitialiseRadiusPacketFromBytes(reply *[]uint8) (protocol.RadiusPacket, error) {
+  return client.host.InitialiseRadiusPacketFromBytes(reply)
 }
 
 // VerifyReply creates RADIUS packet attribute by ID, that is defined in dictionary file

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,8 +13,8 @@ import (
 func TestGetRadiusAttributeOriginalStringValue(t *testing.T) {
   fmt.Println("TESTS")
   
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -26,8 +26,8 @@ func TestGetRadiusAttributeOriginalStringValue(t *testing.T) {
 }
 
 func TestGetRadiusAttributeOriginalStringValueError(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -39,8 +39,8 @@ func TestGetRadiusAttributeOriginalStringValueError(t *testing.T) {
 }
 
 func TestGetRadiusAttributeOriginalIntegerValue(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -53,8 +53,8 @@ func TestGetRadiusAttributeOriginalIntegerValue(t *testing.T) {
 }
 
 func TestGetRadiusAttributeOriginalIntegerValueError(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -66,8 +66,8 @@ func TestGetRadiusAttributeOriginalIntegerValueError(t *testing.T) {
 }
 
 func TestVerifyEmptyReply(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -89,8 +89,8 @@ func TestVerifyEmptyReply(t *testing.T) {
 }
 
 func TestVerifyMalformedReply(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 
@@ -112,8 +112,8 @@ func TestVerifyMalformedReply(t *testing.T) {
 }
 
 func TestVerifyReply(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := protocol.DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
   
   client := InitialiseClient(dictionary, "127.0.0.1", "secret", 1, 2)
 

--- a/protocol/dictionary_test.go
+++ b/protocol/dictionary_test.go
@@ -12,8 +12,8 @@ func TestDictionaryFromFile(t *testing.T) {
   var vendors    []DictionaryVendor
 
 
-  dictPath   := "../dict_examples/test_dictionary_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/test_dictionary_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
 
   attributes = append(attributes, DictionaryAttribute{

--- a/protocol/host_test.go
+++ b/protocol/host_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestGetDictionaryValueByAttrAndValueName(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   host := InitialiseHost(1812, 1813, 3799, dictionary)
 
@@ -20,8 +20,8 @@ func TestGetDictionaryValueByAttrAndValueName(t *testing.T) {
 }
 
 func TestGetDictionaryValueByAttrAndValueNameError(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   host := InitialiseHost(1812, 1813, 3799, dictionary)
 
@@ -31,8 +31,8 @@ func TestGetDictionaryValueByAttrAndValueNameError(t *testing.T) {
 }
 
 func TestGetDictionaryAttributeByID(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   host := InitialiseHost(1812, 1813, 3799, dictionary)
 
@@ -44,8 +44,8 @@ func TestGetDictionaryAttributeByID(t *testing.T) {
 }
 
 func TestGetDictionaryAttributeByIDError(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   host := InitialiseHost(1812, 1813, 3799, dictionary)
 
@@ -55,8 +55,8 @@ func TestGetDictionaryAttributeByIDError(t *testing.T) {
 }
 
 func TestVerifyPacketAttributes(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   packetBytes := []uint8 { 4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
   
@@ -67,8 +67,8 @@ func TestVerifyPacketAttributes(t *testing.T) {
 }
 
 func TestVerifyPacketAttributesFail(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   packetBytes := []uint8 { 4, 43, 0, 82, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 5, 192, 168, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
   host        := InitialiseHost(1812, 1813, 3799, dictionary)
@@ -78,9 +78,9 @@ func TestVerifyPacketAttributesFail(t *testing.T) {
 }
 
 func TestVerifyMessageAuthenticator(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
-  secret     := "secret"
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
+  secret        := "secret"
 
   packetBytes := []uint8 { 1, 120, 0, 185, 49, 79, 108, 150, 27, 203, 166, 51, 193, 68, 15, 76, 208, 114, 171, 48, 1, 9, 116, 101, 115, 116, 105, 110, 103, 80, 18, 164, 201, 132, 0, 209, 101, 200, 189, 252, 251, 120, 224, 74, 190, 232, 197, 2, 66, 85, 125, 163, 190, 40, 210, 235, 231, 112, 96, 7, 94, 27, 95, 241, 63, 23, 81, 25, 136, 36, 209, 238, 119, 131, 113, 118, 14, 160, 16, 94, 184, 143, 37, 193, 138, 124, 238, 85, 197, 21, 17, 206, 158, 87, 132, 239, 59, 82, 183, 175, 54, 124, 138, 5, 245, 166, 195, 181, 106, 41, 31, 129, 183, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 6, 6, 0, 0, 0, 2, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
   host        := InitialiseHost(1812, 1813, 3799, dictionary)
@@ -90,21 +90,21 @@ func TestVerifyMessageAuthenticator(t *testing.T) {
 }
 
 func TestVerifyMessageAuthenticatorWoAuthenticator(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
-  secret     := "secret"
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
+  secret        := "secret"
 
   packetBytes := []uint8 { 4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
   host        := InitialiseHost(1812, 1813, 3799, dictionary)
 
   err := host.VerifyMessageAuthenticator(secret, &packetBytes)
-  assert.Equal(t, "Packet Message-Authenticator mismatch", err.Error(), "Invalid packed is verified!")
+  assert.Equal(t, "Message-Authenticator attribute not found in packet", err.Error(), "Invalid packed is verified!")
 }
 
 func TestVerifyMessageAuthenticatorError(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
-  secret     := "secret"
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
+  secret        := "secret"
 
   packetBytes := []uint8 { 1, 94, 0, 190, 241, 228, 181, 142, 185, 194, 157, 205, 159, 0, 91, 199, 171, 119, 68, 44, 1, 9, 116, 101, 115, 116, 105, 110, 103, 80, 23, 109, 101, 115, 115, 97, 103, 101, 45, 97, 117, 116, 104, 101, 110, 116, 105, 99, 97, 116, 111, 114, 2, 66, 167, 81, 185, 84, 173, 104, 91, 10, 145, 109, 156, 169, 227, 109, 100, 76, 86, 227, 61, 253, 129, 35, 109, 115, 54, 140, 66, 106, 193, 70, 145, 39, 106, 105, 142, 215, 21, 166, 142, 80, 145, 217, 202, 252, 172, 33, 17, 12, 159, 105, 157, 144, 221, 221, 94, 48, 158, 22, 62, 191, 16, 177, 137, 131, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 6, 6, 0, 0, 0, 2, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
   host        := InitialiseHost(1812, 1813, 3799, dictionary)

--- a/protocol/radius_packet_test.go
+++ b/protocol/radius_packet_test.go
@@ -11,8 +11,8 @@ import (
 func TestCreateRadAttributeByName(t *testing.T) {
   expectedRadAttr := RadiusAttribute { 1, "User-Name", []uint8 { 1,2,3 } }
 
-  dictPath   := "../dict_examples/test_dictionary_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/test_dictionary_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   radiusAttribute, _ := CreateRadAttributeByName(&dictionary, "User-Name", &[]uint8 { 1,2,3 })
   assert.Equal(t, expectedRadAttr, radiusAttribute, "Radius Attributes are not same!")
@@ -21,8 +21,8 @@ func TestCreateRadAttributeByName(t *testing.T) {
 func TestCreateRadAttributeByNameNonExisting(t *testing.T) {
   expectedRadAttr := RadiusAttribute{}
 
-  dictPath   := "../dict_examples/test_dictionary_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/test_dictionary_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   radiusAttribute, ok := CreateRadAttributeByName(&dictionary, "Non-Existing", &[]uint8 { 1,2,3 })
   assert.Equal(t, expectedRadAttr, radiusAttribute, "Radius Attributes are not same!")
@@ -32,8 +32,8 @@ func TestCreateRadAttributeByNameNonExisting(t *testing.T) {
 func TestCreateRadAttributeByID(t *testing.T) {
   expectedRadAttr := RadiusAttribute { 5, "NAS-Port-Id", []uint8 { 1,2,3 } }
 
-  dictPath   := "../dict_examples/test_dictionary_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/test_dictionary_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   radiusAttribute, _ := CreateRadAttributeByID(&dictionary, 5, &[]uint8 { 1,2,3 })
   assert.Equal(t, expectedRadAttr, radiusAttribute, "Radius Attributes are not same!")
@@ -43,8 +43,8 @@ func TestCreateRadAttributeByID(t *testing.T) {
 func TestCreateRadAttributeByIDNonExisting(t *testing.T) {
   expectedRadAttr := RadiusAttribute{}
 
-  dictPath   := "../dict_examples/test_dictionary_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/test_dictionary_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   radiusAttribute, ok := CreateRadAttributeByID(&dictionary, 205, &[]uint8 { 1,2,3 })
   assert.Equal(t, expectedRadAttr, radiusAttribute, "Radius Attributes are not same!")
@@ -54,8 +54,8 @@ func TestCreateRadAttributeByIDNonExisting(t *testing.T) {
 func TestInitialiseRadPacketFromBytes(t *testing.T) {
   radPacketBytes := []uint8 { 4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
 
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   nasIPAddrBytes, _    := tools.IPv4StringToBytes("192.168.1.10")
   nasPortIDBytes       := tools.IntegerToBytes(0)
@@ -74,20 +74,20 @@ func TestInitialiseRadPacketFromBytes(t *testing.T) {
   attributes := []RadiusAttribute { nasIPAttr, nasPortAttr, nasIDAttr, calledSIDAttr, callingSIDAttr, framedIPAttr }
   authenticator := []uint8 { 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73 }
 
-  expectedPacket := InitialiseRadPacket(AccountingRequest)
+  expectedPacket := InitialiseRadiusPacket(AccountingRequest)
 
   expectedPacket.SetAttributes(attributes)
   expectedPacket.OverrideID(43)
   expectedPacket.OverrideAuthenticator(authenticator)
 
-  packetFromBytes, _ := InitialiseRadPacketFromBytes(&dictionary, &radPacketBytes)
+  packetFromBytes, _ := InitialiseRadiusPacketFromBytes(&dictionary, &radPacketBytes)
   assert.Equal(t, expectedPacket, packetFromBytes, "Radius Packets are not same!")
 }
 
 func TestOverrideID(t *testing.T) {
   expectedID := uint8(50)
 
-  radPacket := InitialiseRadPacket(AccountingRequest)
+  radPacket := InitialiseRadiusPacket(AccountingRequest)
 
   radPacket.OverrideID(expectedID)
   assert.Equal(t, expectedID, radPacket.ID(), "Radius Packet ID was not changed!")
@@ -96,7 +96,7 @@ func TestOverrideID(t *testing.T) {
 func TestOverrideAuthenticator(t *testing.T) {
   expectedAuthenticator := []uint8 { 0, 25, 100, 56, 13 }
 
-  radPacket := InitialiseRadPacket(AccountingRequest)
+  radPacket := InitialiseRadiusPacket(AccountingRequest)
 
   radPacket.OverrideAuthenticator(expectedAuthenticator)
   assert.Equal(t, expectedAuthenticator, radPacket.Authenticator(), "Radius Packet Authhenticator was not changed!")
@@ -105,43 +105,46 @@ func TestOverrideAuthenticator(t *testing.T) {
 func TestRadiusPacketToBytes(t *testing.T) {
   expectedPacketBytes := []uint8 { 1, 50, 0, 29, 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153, 0, 1, 2, 3, 1, 9, 116, 101, 115, 116, 105, 110, 103 }
   
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
 
   userName        := []uint8("testing")
   userNameAttr, _ := CreateRadAttributeByName(&dictionary, "User-Name", &userName)
   attributes      := []RadiusAttribute { userNameAttr }
   newAuthenticator := []uint8 { 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153, 0, 1, 2, 3 }
 
-  radPacket := InitialiseRadPacket(AccessRequest)
+  radPacket := InitialiseRadiusPacket(AccessRequest)
   radPacket.SetAttributes(attributes)
   radPacket.OverrideID(50)
   radPacket.OverrideAuthenticator(newAuthenticator)
 
-  assert.Equal(t, expectedPacketBytes, radPacket.ToBytes(), "Radius Packet was not converted to correct bytes!")
+  packetBytes, _ := radPacket.ToBytes()
+  assert.Equal(t, expectedPacketBytes, packetBytes, "Radius Packet was not converted to correct bytes!")
 }
 
 func TestOverrideMessageAuthenticator(t *testing.T) {
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
   
   initMessageAuthenticator := []uint8 { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
   newMessageAuthenticator  := []uint8 { 1, 50, 0, 20, 0, 25, 100, 56, 13, 0, 67, 34, 39, 12, 88, 153 }
   msgAuthAttr, _           := CreateRadAttributeByName(&dictionary, "Message-Authenticator", &initMessageAuthenticator)
   attributes               := []RadiusAttribute { msgAuthAttr }
 
-  radPacket := InitialiseRadPacket(AccessRequest)
+  radPacket := InitialiseRadiusPacket(AccessRequest)
   radPacket.SetAttributes(attributes)
 
   radPacket.OverrideMessageAuthenticator(newMessageAuthenticator)
-  assert.Equal(t, newMessageAuthenticator, radPacket.MessageAuthenticator(), "Radius Packet Authhenticator was not changed!") 
+
+  msgAuthenticator, _ := radPacket.MessageAuthenticator()
+  assert.Equal(t, newMessageAuthenticator, msgAuthenticator, "Radius Packet Authhenticator was not changed!") 
 }
 
 func TestGenerateMessageAuthenticator(t *testing.T) {
   expectedMessageAuthenticatorBytes := []uint8 { 85, 134, 2, 170, 83, 101, 202, 79, 109, 163, 59, 12, 66, 170, 183, 220 }
 
-  dictPath   := "../dict_examples/integration_dict"
-  dictionary := DictionaryFromFile(dictPath)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := DictionaryFromFile(dictPath)
   
   secret           := "secret"
   newAuthenticator := []uint8 { 152, 137, 115, 14, 56, 250, 103, 56, 57, 57, 104, 246, 226, 80, 71, 167 }
@@ -153,12 +156,13 @@ func TestGenerateMessageAuthenticator(t *testing.T) {
   msgAuthAttr, _  := CreateRadAttributeByName(&dictionary, "Message-Authenticator", &messageAuthBytes)
   attributes      := []RadiusAttribute { userNameAttr, msgAuthAttr }
 
-  radPacket := InitialiseRadPacket(AccessRequest)
+  radPacket := InitialiseRadiusPacket(AccessRequest)
   radPacket.SetAttributes(attributes)
   radPacket.OverrideID(220)
   radPacket.OverrideAuthenticator(newAuthenticator)
 
   radPacket.GenerateMessageAuthenticator(secret)
 
-  assert.Equal(t, expectedMessageAuthenticatorBytes, radPacket.MessageAuthenticator(), "Radius Packet Message Authhenticator was not set to correct bytes!")
+  msgAuthenticator, _ := radPacket.MessageAuthenticator()
+  assert.Equal(t, expectedMessageAuthenticatorBytes, msgAuthenticator, "Radius Packet Message Authhenticator was not set to correct bytes!")
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,9 +11,9 @@ import (
 func TestCreateReplyPacket(t *testing.T) {
   expectedReplyBytes := []uint8 { 5, 43, 0, 29, 109, 214, 15, 125, 92, 239, 190, 144, 171, 115, 202, 187, 72, 208, 115, 25, 1, 9, 116, 101, 115, 116, 105, 110, 103 }
 
-  dictPath     := "../dict_examples/integration_dict"
-  dictionary   := protocol.DictionaryFromFile(dictPath)
-  allowedHosts := make(map[string]string)
+  dictPath      := "../dict_examples/integration_dict"
+  dictionary, _ := protocol.DictionaryFromFile(dictPath)
+  allowedHosts  := make(map[string]string)
 
   allowedHosts["123.123.123.123"] = "secret"
   
@@ -25,6 +25,7 @@ func TestCreateReplyPacket(t *testing.T) {
 
   request := []uint8 { 4, 43, 0, 83, 215, 189, 213, 172, 57, 94, 141, 70, 134, 121, 101, 57, 187, 220, 227, 73, 4, 6, 192, 168, 1, 10, 5, 6, 0, 0, 0, 0, 32, 10, 116, 114, 105, 108, 108, 105, 97, 110, 30, 19, 48, 48, 45, 48, 52, 45, 53, 70, 45, 48, 48, 45, 48, 70, 45, 68, 49, 31, 19, 48, 48, 45, 48, 49, 45, 50, 52, 45, 56, 48, 45, 66, 51, 45, 57, 67, 8, 6, 10, 0, 0, 100 }
 
-  replyPacket := server.CreateReplyPacket(protocol.AccountingResponse, attributes, &request, server.Secret("123.123.123.123"))
-  assert.Equal(t, expectedReplyBytes, replyPacket.ToBytes(), "Reply bytes do not match!")
+  replyPacket, _      := server.CreateReplyPacket(protocol.AccountingResponse, attributes, &request, server.Secret("123.123.123.123"))
+  replyPacketBytes, _ := replyPacket.ToBytes()
+  assert.Equal(t, expectedReplyBytes, replyPacketBytes, "Reply bytes do not match!")
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -53,7 +53,7 @@ func TestIPv4BytesToString(t *testing.T) {
 }
 
 func TestIntegerToBytes(t *testing.T) {
-  expectedBytes := []uint8{ 0, 0, 39, 16 } 
+  expectedBytes := []uint8{ 0, 0, 39, 16 }
 
   integer := uint32(10000)
   assert.Equal(t, expectedBytes, IntegerToBytes(integer), "Integer bytes is not correct!")
@@ -62,10 +62,26 @@ func TestIntegerToBytes(t *testing.T) {
 func TestBytesToInteger(t *testing.T) {
   expectedInteger := uint32(10000)
 
-  integerBytes := []uint8{ 0, 0, 39, 16 } 
+  integerBytes := []uint8{ 0, 0, 39, 16 }
 
   integer, _ := BytesToInteger(integerBytes)
   assert.Equal(t, expectedInteger, integer, "Integer is not correct!")
+}
+
+func TestInteger64ToBytes(t *testing.T) {
+  expectedBytes := []uint8{ 0, 0, 0, 0, 0, 0, 39, 16 }
+
+  integer := uint64(10000)
+  assert.Equal(t, expectedBytes, Integer64ToBytes(integer), "Integer64 bytes is not correct!")
+}
+
+func TestBytesToInteger64(t *testing.T) {
+  expectedInteger := uint64(10000)
+
+  integerBytes := []uint8{ 0, 0, 0, 0, 0, 0, 39, 16 }
+
+  integer, _ := BytesToInteger64(integerBytes)
+  assert.Equal(t, expectedInteger, integer, "Integer64 is not correct!")
 }
 
 func TestTimestampToBytes(t *testing.T) {


### PR DESCRIPTION
1. Made sure protocol is now returns (value, error) OR (value, bool) from all functions where it makes sense - error when something can go wrong, ie File is not present & bool where there is a potential for a value not to be present, ie SupportAttributeTypes
2. Tools now handle all core data types:
    1. text
    2. string
    3. integer
    4. integer64
    5. time
    6. ipv4add, ipadr & ipv4prefix
    7. ipv6addr & ipv6prefix
    8. ifid
3. Client & Server generic implementations are updated to use above changes